### PR TITLE
Transform split result correctly

### DIFF
--- a/lib/hocho/inventory.rb
+++ b/lib/hocho/inventory.rb
@@ -22,7 +22,7 @@ module Hocho
 
     def filter(filters)
       filters = filters.map do |name, value|
-        [name.to_s, value.to_s.split(?,) { |_| /#{Regexp.escape(_).gsub(/\\*/,'.*')}/ }]
+        [name.to_s, value.to_s.split(?,).map! { |_| /#{Regexp.escape(_).gsub(/\\*/,'.*')}/ }]
       end.to_h
 
       hosts.select do |host|


### PR DESCRIPTION
## Problem
hocho can't be used with Ruby trunk (r62763+)

```
$ bundle exec hocho apply foo
bundler: failed to load command: hocho (/home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bin/hocho)
NoMethodError: undefined method `any?' for "foo":String
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/lib/hocho/inventory.rb:32:in `block (2 levels) in filter'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/lib/hocho/inventory.rb:29:in `each'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/lib/hocho/inventory.rb:29:in `all?'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/lib/hocho/inventory.rb:29:in `block in filter'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/lib/hocho/inventory.rb:28:in `select'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/lib/hocho/inventory.rb:28:in `filter'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/lib/hocho/command.rb:57:in `apply'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bundler/gems/hocho-66f95cce828f/bin/hocho:4:in `<top (required)>'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bin/hocho:23:in `load'
  /home/k0kubun/.rbenv/versions/ruby/lib/ruby/gems/2.6.0/bin/hocho:23:in `<top (required)>'
```

## Cause
String#split had not taken a block, and it started to use the block and return string since r62763 https://bugs.ruby-lang.org/issues/4780

## Change
Transform the String#split result using `#map!`.

<hr>

P.S. Please push a new version to rubygems.org after merging.