### PR TITLE
Allow disabling -z by compress property

### DIFF
--- a/lib/hocho/drivers/ssh_base.rb
+++ b/lib/hocho/drivers/ssh_base.rb
@@ -21,14 +21,15 @@ module Hocho
 
         ssh_cmd = ['ssh', *host.openssh_config.flat_map { |l| ['-o', "\"#{l}\""] }].join(' ')
         shm_exclude = shm_prefix.map{ |_| "--exclude=#{_}" }
-        rsync_cmd = [*%w(rsync -az --copy-links --copy-unsafe-links --delete --exclude=.git), *shm_exclude, '--rsh', ssh_cmd, '.', "#{host.hostname}:#{host_basedir}"]
+        compress = host.compress? ? ['-z'] : []
+        rsync_cmd = [*%w(rsync -a --copy-links --copy-unsafe-links --delete --exclude=.git), *compress, *shm_exclude, '--rsh', ssh_cmd, '.', "#{host.hostname}:#{host_basedir}"]
 
         puts "=> $ #{rsync_cmd.shelljoin}"
         system(*rsync_cmd, chdir: base_dir) or raise 'failed to rsync'
 
         unless shm_prefix.empty?
           shm_include = shm_prefix.map{ |_| "--include=#{_.sub(%r{/\z},'')}/***" }
-          rsync_cmd = [*%w(rsync -az --copy-links --copy-unsafe-links --delete), *shm_include, '--exclude=*', '--rsh', ssh_cmd, '.', "#{host.hostname}:#{host_shm_basedir}"]
+          rsync_cmd = [*%w(rsync -a --copy-links --copy-unsafe-links --delete), *compress, *shm_include, '--exclude=*', '--rsh', ssh_cmd, '.', "#{host.hostname}:#{host_shm_basedir}"]
           puts "=> $ #{rsync_cmd.shelljoin}"
           system(*rsync_cmd, chdir: base_dir) or raise 'failed to rsync'
           shm_prefix.each do |x|

--- a/lib/hocho/host.rb
+++ b/lib/hocho/host.rb
@@ -206,5 +206,9 @@ module Hocho
         retry
       end
     end
+
+    def compress?
+      properties.fetch(:compress, true)
+    end
   end
 end


### PR DESCRIPTION
When I used hocho on an Arch Linux server, I got:
```
=> $ rsync -az --copy-links --copy-unsafe-links --delete --exclude\=.git --rsh ssh\ -o\ \"PubkeyAuthentication\=yes\"\ -o\ \"PasswordAuthentication\=yes\"\ -o\ \"PreferredAuthentications\=none,publickey,password,keyboard-interactive\"\ -o\ \"User\=k0kubun\" . chkbuild006.hsbt.org:/tmp/hocho-run-5ybRSjNad/itamae
Enter passphrase for key '/Users/k0kubun/.ssh/id_rsa':
rsync: This rsync lacks old-style --compress due to its external zlib.  Try -zz.
rsync error: syntax or usage error (code 1) at main.c(1578) [server=3.1.3]
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: error in rsync protocol data stream (code 12) at /BuildRoot/Library/Caches/com.apple.xbs/Sources/rsync/rsync-54/rsync/io.c(453) [sender=2.6.9]
```

I tried changing `-z` to `-zz` as instructed by that, but it didn't work. So I'd like to have a property to just disable compression.

```yml
foo.bar:
  properties:
    compress: false
```