### PR TITLE
Delete strict_host_key_checking from ssh_options if net-ssh does not support it

### DIFF
--- a/lib/hocho/host.rb
+++ b/lib/hocho/host.rb
@@ -169,13 +169,13 @@ module Hocho
         when :verify_host_key
           case value
           when :never
-            [["StrictHostKeyChecking", 'no']]
+            [["StrictHostKeyChecking", "no"]]
           when :accept_new_or_local_tunnel
-            [["StrictHostKeyChecking", 'accept-new']]
+            [["StrictHostKeyChecking", "accept-new"]]
           when :accept_new
-            [["StrictHostKeyChecking", 'accept-new']]
+            [["StrictHostKeyChecking", "accept-new"]]
           when :always
-            [["StrictHostKeyChecking", 'yes']]
+            [["StrictHostKeyChecking", "yes"]]
           end
         end
       end.compact.map do |keyval|

--- a/lib/hocho/host.rb
+++ b/lib/hocho/host.rb
@@ -166,6 +166,17 @@ module Hocho
          [["User", value]]
         when :user_known_hosts_file
          [["UserKnownHostsFile", value]]
+        when :verify_host_key
+          case value
+          when :never
+            [["StrictHostKeyChecking", 'no']]
+          when :accept_new_or_local_tunnel
+            [["StrictHostKeyChecking", 'accept-new']]
+          when :accept_new
+            [["StrictHostKeyChecking", 'accept-new']]
+          when :always
+            [["StrictHostKeyChecking", 'yes']]
+          end
         end
       end.compact.map do |keyval|
         keyval.join(separator)

--- a/lib/hocho/host.rb
+++ b/lib/hocho/host.rb
@@ -198,8 +198,12 @@ module Hocho
 
     def make_ssh_connection
       alt = false
+      options = ssh_options
+      unless Net::SSH::VALID_OPTIONS.include?(:strict_host_key_checking)
+        options.delete(:strict_host_key_checking)
+      end
       begin
-        Net::SSH.start(name, nil, ssh_options)
+        Net::SSH.start(name, nil, options)
       rescue Net::SSH::Exception, Errno::ECONNREFUSED, Net::SSH::Proxy::ConnectError => e
         raise if alt
         raise unless alternate_ssh_options_available?

--- a/lib/hocho/host.rb
+++ b/lib/hocho/host.rb
@@ -209,6 +209,9 @@ module Hocho
 
     def make_ssh_connection
       alt = false
+      # A workaround for a bug on net-ssh: https://github.com/net-ssh/net-ssh/issues/764
+      # :strict_host_key_checking is translated from ssh config. However, Net::SSH.start does not accept
+      # the option as valid one. Remove this part when net-ssh fixes the bug.
       options = ssh_options
       unless Net::SSH::VALID_OPTIONS.include?(:strict_host_key_checking)
         options.delete(:strict_host_key_checking)


### PR DESCRIPTION
## Background

[net-ssh does not accept :strict_host_key_checking as a valid ssh option](https://github.com/net-ssh/net-ssh/blob/3768f1f1a81504909df7b9ee95fdd16f6610096d/lib/net/ssh.rb#L66-L78). As a result, hocho produces an error when ssh config has StrictHostKeyChecking option. This PR removes :strict_host_key_checking from ssh_options when net-ssh does not support it.

<details>
<summary>SSH config</summary>

```
Host host-001.example.com
  User dummy-user
  CheckHostIP no
  StrictHostKeyChecking no
  IdentityFile ~/.ssh/dummy_key
  Port 22
```
</details>

<details>
<summary>Error</summary>

```
bundle exec hocho apply --dry-run host-001.example.com
=> Running on taka-test-001.example.com using mitamae
bundler: failed to load command: hocho (/Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bin/hocho)
ArgumentError: invalid option(s): strict_host_key_checking
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/net-ssh-6.0.2/lib/net/ssh.rb:221:in `start'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/host.rb:202:in `make_ssh_connection'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/host.rb:196:in `ssh_connection'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/drivers/ssh_base.rb:9:in `ssh'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/drivers/mitamae.rb:17:in `run'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/runner.rb:22:in `run'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/command.rb:85:in `block in apply'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/command.rb:77:in `each'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/lib/hocho/command.rb:77:in `apply'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/hocho-0.3.4/bin/hocho:4:in `<top (required)>'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bin/hocho:23:in `load'
  /Users/takayuki-watanabe/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bin/hocho:23:in `<top (required)>'
status_code:1
```
</details>

## Changes

* Delete strict_host_key_checking from ssh_options if it's not a valid option.

## Related links

* [valid ssh options for net-ssh](https://github.com/net-ssh/net-ssh/blob/3768f1f1a81504909df7b9ee95fdd16f6610096d/lib/net/ssh.rb#L66-L78)

