### PR TITLE
Change Compression=true into Compression=yes

### DIFF
--- a/lib/hocho/host.rb
+++ b/lib/hocho/host.rb
@@ -107,7 +107,7 @@ module Hocho
         when :encryption
          [["Ciphers", [*value].join(?,)]]
         when :compression
-         [["Compression", value]]
+         [["Compression", value ? 'yes' : 'no']]
         when :compression_level
          [["CompressionLevel", value]]
         when :timeout


### PR DESCRIPTION
`Compression` is a boolean flag, where OpenSSH expects `yes` or `no` value, but we have given `true`/`false` here.
This led to `command-line line 0: unsupported option "true"` complaint from OpenSSH in certain environments.