### PR TITLE
Fix keyword argument error when running 'hocho show' in Ruby 3.0

### DIFF
--- a/lib/hocho/command.rb
+++ b/lib/hocho/command.rb
@@ -36,7 +36,7 @@ module Hocho
     desc "show NAME", ""
     method_option :format, enum: %w(yaml json), default: 'yaml'
     def show(name)
-      host = inventory.filter(name: name).first
+      host = inventory.filter({name: name}).first
       if host
         case options[:format]
         when 'yaml'


### PR DESCRIPTION
This pull request fixes the `hocho show` error in Ruby 3.0.

If there are no problems with the fix, I would appreciate it if you could reflect them.

before: 

```
$ pwd
/Users/msfukui/projects/pitanetes
$ ruby -v
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
$ bundle exec hocho show framy
bundler: failed to load command: hocho (/Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/bin/hocho)
/Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/gems/hocho-0.3.7/lib/hocho/inventory.rb:23:in `filter': wrong number of arguments (given 0, expected 1) (ArgumentError)
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/gems/hocho-0.3.7/lib/hocho/command.rb:39:in `show'
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor/command.rb:27:in `run'
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor.rb:392:in `dispatch'
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/gems/thor-1.0.1/lib/thor/base.rb:485:in `start'
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/gems/hocho-0.3.7/bin/hocho:4:in `<top (required)>'
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/bin/hocho:23:in `load'
	from /Users/msfukui/projects/pitanetes/vendor/bundle/ruby/3.0.0/bin/hocho:23:in `<top (required)>'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `load'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli/exec.rb:63:in `kernel_load'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli/exec.rb:28:in `run'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli.rb:497:in `exec'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli.rb:30:in `dispatch'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/cli.rb:24:in `start'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/bundler-2.2.3/libexec/bundle:49:in `block in <top (required)>'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/3.0.0/bundler/friendly_errors.rb:130:in `with_friendly_errors'
	from /Users/msfukui/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/bundler-2.2.3/libexec/bundle:37:in `<top (required)>'
	from /Users/msfukui/.rbenv/versions/3.0.0/bin/bundle:23:in `load'
	from /Users/msfukui/.rbenv/versions/3.0.0/bin/bundle:23:in `<main>'
```

after: 

```
$ bundle exec hocho show framy
---
:name: framy
:providers:
- !ruby/class 'Hocho::InventoryProviders::File'
:tags: {}
:properties:
  nopasswd_sudo: true
  run_list: !ruby/array:Hashie::Array
  - recipes/default.rb
  preferred_driver: mitamae
:ssh_options:
  :user: pi
```
