### PR TITLE
Add --keep-synced-files to the 'apply' command

### DIFF
--- a/lib/hocho/command.rb
+++ b/lib/hocho/command.rb
@@ -54,6 +54,8 @@ module Hocho
     method_option :dry_run, type: :boolean, default: false, aliases: %w(-n)
     method_option :exclude, type: :string, default: '', aliases: %w(-e)
     method_option :driver, type: :string
+    method_option :keep_synced_files, type: :boolean, default: false,
+                  desc: "Keep the recipes on a server after run (for bundler and mitamae drivers)"
     def apply(name)
       hosts = inventory.filter({name: name}, exclude_filters: {name: options[:exclude]})
       if hosts.empty?
@@ -84,8 +86,11 @@ module Hocho
           driver_options: config[:driver_options] || {},
         ).run(
           dry_run: options[:dry_run],
+          keep_synced_files: options[:keep_synced_files]
         )
       end
+    rescue Hocho::Utils::Finder::NotFound => e
+      abort e.message
     end
 
     private

--- a/lib/hocho/drivers/bundler.rb
+++ b/lib/hocho/drivers/bundler.rb
@@ -3,13 +3,15 @@ require 'hocho/drivers/ssh_base'
 module Hocho
   module Drivers
     class Bundler < SshBase
-      def initialize(host, base_dir: '.', initializers: [], itamae_options: [], bundle_without: [], bundle_path: nil, deploy_options: {})
+      def initialize(host, base_dir: '.', initializers: [], itamae_options: [], bundle_without: [], bundle_path: nil,
+                     deploy_options: {}, keep_synced_files: false, **)
         super host, base_dir: base_dir, initializers: initializers
 
         @itamae_options = itamae_options
         @bundle_without = bundle_without
         @bundle_path = bundle_path
         @deploy_options = deploy_options
+        @keep_synced_files = keep_synced_files
       end
 
       def run(dry_run: false)

--- a/lib/hocho/drivers/itamae_ssh.rb
+++ b/lib/hocho/drivers/itamae_ssh.rb
@@ -4,7 +4,7 @@ require 'shellwords'
 module Hocho
   module Drivers
     class ItamaeSsh < Base
-      def initialize(host, base_dir: '.', initializers: [], itamae_options: [])
+      def initialize(host, base_dir: '.', initializers: [], itamae_options: [], **)
         super host, base_dir: base_dir, initializers: initializers
         @itamae_options = itamae_options
       end

--- a/lib/hocho/drivers/mitamae.rb
+++ b/lib/hocho/drivers/mitamae.rb
@@ -3,7 +3,9 @@ require 'hocho/drivers/ssh_base'
 module Hocho
   module Drivers
     class Mitamae < SshBase
-      def initialize(host, base_dir: '.', mitamae_path: 'mitamae', mitamae_prepare_script: [], mitamae_outdate_check_script: nil, initializers: [], mitamae_options: [], deploy_options: {})
+      def initialize(host, base_dir: '.', mitamae_path: 'mitamae', mitamae_prepare_script: [],
+                     mitamae_outdate_check_script: nil, initializers: [], mitamae_options: [],
+                     deploy_options: {}, keep_synced_files: false, **)
         super host, base_dir: base_dir, initializers: initializers
 
         @mitamae_path = mitamae_path
@@ -11,6 +13,7 @@ module Hocho
         @mitamae_outdate_check_script = mitamae_outdate_check_script
         @mitamae_options = mitamae_options
         @deploy_options = deploy_options
+        @keep_synced_files = keep_synced_files
       end
 
       def run(dry_run: false)

--- a/lib/hocho/drivers/ssh_base.rb
+++ b/lib/hocho/drivers/ssh_base.rb
@@ -10,10 +10,14 @@ module Hocho
       end
 
       def finalize
+        return if @keep_synced_files
+
         remove_host_tmpdir!
         remove_host_shmdir!
       end
 
+      # @param deploy_dir [String] path on the server to copy the files to. If not specified, an automatic dir in /tmp is used
+      # @param shm_prefix [Array<String>] additional directories that will be copied to /dev/shm on the server
       def deploy(deploy_dir: nil, shm_prefix: [])
         @host_basedir = deploy_dir if deploy_dir
 
@@ -44,12 +48,6 @@ module Hocho
         end
 
         yield
-      ensure
-        if !deploy_dir || !keep_synced_files
-          cmd = "rm -rf #{host_basedir.shellescape}"
-          puts "=> #{host.name} $ #{cmd}"
-          ssh_run(cmd, error: false)
-        end
       end
 
       private

--- a/lib/hocho/runner.rb
+++ b/lib/hocho/runner.rb
@@ -14,9 +14,12 @@ module Hocho
 
     attr_reader :host, :driver, :base_dir, :initializers
 
-    def run(dry_run: false)
+    def run(dry_run: false, keep_synced_files: false)
       puts "=> Running on #{host.name} using #{best_driver_name}"
       driver_options = @driver_options[best_driver_name] || {}
+
+      driver_options[:keep_synced_files] = keep_synced_files
+
       driver = best_driver.new(host, base_dir: base_dir, initializers: initializers, **driver_options)
       driver.run(dry_run: dry_run)
     ensure

--- a/spec/drivers/bundler_spec.rb
+++ b/spec/drivers/bundler_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'hocho/drivers/bundler'
+
+RSpec.describe Hocho::Drivers::Bundler do
+  it "ignores unknown initialize arguments" do
+    expect { described_class.new(double, foo: :bar) }.not_to raise_error
+  end
+end

--- a/spec/drivers/itamae_ssh_spec.rb
+++ b/spec/drivers/itamae_ssh_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'hocho/drivers/itamae_ssh'
+
+RSpec.describe Hocho::Drivers::ItamaeSsh do
+  it "ignores unknown initialize arguments" do
+    expect { described_class.new(double, foo: :bar) }.not_to raise_error
+  end
+end

--- a/spec/drivers/mitamae_spec.rb
+++ b/spec/drivers/mitamae_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+require 'hocho/drivers/mitamae'
+
+RSpec.describe Hocho::Drivers::Mitamae do
+  it "ignores unknown initialize arguments" do
+    expect { described_class.new(double, foo: :bar) }.not_to raise_error
+  end
+end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'hocho/runner'
+require 'hocho/drivers/bundler'
+require 'hocho/drivers/itamae_ssh'
+require 'hocho/drivers/mitamae'
+
+RSpec.describe Hocho::Runner do
+  let(:host) { double(:host, name: "example.com") }
+
+  it "runs bundler" do
+    instance = described_class.new(host, driver: :bundler)
+    expect_any_instance_of(Hocho::Drivers::Bundler).to receive(:run)
+
+    expect { instance.run }.to output("=> Running on example.com using bundler\n").to_stdout
+  end
+
+  it "runs itamae via ssh" do
+    instance = described_class.new(host, driver: :itamae_ssh)
+    expect_any_instance_of(Hocho::Drivers::ItamaeSsh).to receive(:run)
+
+    expect { instance.run }.to output("=> Running on example.com using itamae_ssh\n").to_stdout
+  end
+
+  it "runs mitamae" do
+    instance = described_class.new(host, driver: :mitamae)
+    expect_any_instance_of(Hocho::Drivers::Mitamae).to receive(:run)
+
+    expect { instance.run }.to output("=> Running on example.com using mitamae\n").to_stdout
+  end
+
+  it "complains about unknown driver" do
+    instance = described_class.new(host, driver: :foo)
+
+    expect { instance.run }
+      .to raise_error(Hocho::Utils::Finder::NotFound)
+      .and output("=> Running on example.com using foo\n").to_stdout
+  end
+end


### PR DESCRIPTION
Per https://github.com/sorah/hocho/issues/13.

This options is only applicable to ssh-based drivers, i.e.: bundler, mitamae. It's not applicable to itamae_ssh as this driver doesn't copy the files, so there's nothing to keep or remove.

Drivers are set to ignore unknown arguments passed via kwargs.
