### PR TITLE
Use YAML.safe_load_file instead of YAML.load_file

### DIFF
--- a/lib/hocho/inventory_providers/file.rb
+++ b/lib/hocho/inventory_providers/file.rb
@@ -23,7 +23,11 @@ module Hocho
 
       def hosts
         @hosts ||= files.flat_map do |file|
-          content = Hocho::Utils::Symbolize.keys_of(YAML.load_file(file))
+          content = Hocho::Utils::Symbolize.keys_of(
+            YAML.safe_load_file(
+              file,
+              permitted_classes: [Symbol, Net::SSH::Proxy::Jump, Net::SSH::Proxy::Command]),
+          )
           content.map do |name, value|
             Host.new(
               name.to_s,


### PR DESCRIPTION
I ran into the following error when I set up the SSH proxy with `Net::SSH::Proxy::Jump` in Ruby 3.1.

```sh
ruby --version
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-darwin20]
```

sample yaml
```yaml
---
example:
  :ssh_options:
    :host_name: example.com
    :proxy: !ruby/object:Net::SSH::Proxy::Jump
      jump_proxies: h-izu@example.com
```

error

```
/Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Net::SSH::Proxy::Jump (Psych::DisallowedClass)
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/class_loader.rb:28:in `load'
~~
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:335:in `safe_load'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:370:in `load'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:671:in `block in load_file'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:670:in `open'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:670:in `load_file'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory_providers/file.rb:26:in `block in hosts'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory_providers/file.rb:25:in `each'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory_providers/file.rb:25:in `flat_map'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory_providers/file.rb:25:in `hosts'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory.rb:10:in `block in hosts'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory.rb:9:in `each'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory.rb:9:in `inject'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory.rb:9:in `hosts'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/inventory.rb:41:in `filter'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/hocho-0.3.8/lib/hocho/command.rb:58:in `apply'
~~
```


This is because Ruby 3.1, with Psych 4.0.0, introduces breaking changes to `YAML.load_file`.

ref. https://bugs.ruby-lang.org/issues/17866
ref. https://techlife.cookpad.com/entry/2021/12/25/220002

In this PR, I changed the code to use `YAML.safe_load_file` instead of `YAML.load_file` and specified `permitted_classes`. I confirmed that it worked on Ruby 3.1 with the ssh proxy of `Net::SSH::Proxy::Jump`, but I haven't confirmed its behavior in other cases.

error when `YAML.safe_load_file` permits `Net::SSH::Proxy::Jump` and `Net::SSH::Proxy::Command`

```
/Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Symbol (Psych::DisallowedClass)
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/class_loader.rb:28:in `load'
	from (eval):2:in `symbol'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/class_loader.rb:32:in `symbolize'
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych/class_loader.rb:84:in `symbolize'
~~
	from /Users/hiroakiizu/.rbenv/versions/3.1.2/lib/ruby/3.1.0/psych.rb:659:in `safe_load_file'
	from /Users/hiroakiizu/ghq/github.com/akihiro17/hocho/lib/hocho/inventory_providers/file.rb:27:in `block in hosts'
	from /Users/hiroakiizu/ghq/github.com/akihiro17/hocho/lib/hocho/inventory_providers/file.rb:25:in `each'
	from /Users/hiroakiizu/ghq/github.com/akihiro17/hocho/lib/hocho/inventory_providers/file.rb:25:in `flat_map'
	from /Users/hiroakiizu/ghq/github.com/akihiro17/hocho/lib/hocho/inventory_providers/file.rb:25:in `hosts'
```